### PR TITLE
Simple Demo updated: 1) stretched font; 2) TODO for SH1106 @ 0x3C

### DIFF
--- a/examples/simple_demo/simple_demo.ino
+++ b/examples/simple_demo/simple_demo.ino
@@ -2,39 +2,50 @@
 // Small Simple OLED library demo
 //
 #include <ss_oled.h>
+static int rc;
 
 void setup() {
-int rc;
   // put your setup code here, to run once:
-rc = oledInit(OLED_128x64, 0, 0, -1, -1,400000L); // use standard I2C bus at 400Khz
-//rc = oledInit(OLED_128x64, 0, 0, 0xb0, 0xb2, 400000L); // for ATtiny85, use P0 as SDA and P2 as SCL
+  rc = oledInit(OLED_128x64, 0, 0, -1, -1, 400000L);        // use standard I2C bus at 400Khz
+//rc = oledInit(OLED_128x64, 0, 0, 0xb0, 0xb2, 400000L);    // for ATtiny85, use P0 as SDA and P2 as SCL
+
   if (rc != OLED_NOT_FOUND)
   {
     char *msgs[] = {"SSD1306 @ 0x3C", "SSD1306 @ 0x3D","SH1106 @ 0x3C","SH1106 @ 0x3D"};
     oledFill(0, 1);
-    oledWriteString(0,0,0,msgs[rc], FONT_NORMAL, 0, 1);
-    delay(2000);
+    oledWriteString(0, 3, 0, (char *)"OLED found:", FONT_NORMAL, 0, 1);
+    oledWriteString(0, 3, 2, msgs[rc], FONT_NORMAL, 0, 1);
+    delay(3000);
   }
 }
 
 void loop() {
   // put your main code here, to run repeatedly:
-int i, x, y;
-char szTemp[32];
+  int i, j, x, y;
+  char szTemp[32];
 
   oledFill(0x0, 1);
-  oledWriteString(0,16,0,(char *)"ss_oled Demo", FONT_NORMAL, 0, 1);
-  oledWriteString(0,0,1,(char *)"Written by Larry Bank", FONT_SMALL, 1, 1);
-  oledWriteString(0,0,3,(char *)"**Demo**", FONT_LARGE, 0, 1);
+  oledWriteString(0, 16, 0,(char *)"ss_oled Demo", FONT_NORMAL, 0, 1);
+  oledWriteString(0, 0, 1,(char *)"Written by Larry Bank", FONT_SMALL, 1, 1);
+  oledWriteString(0, 0, 3,(char *)"**Demo**", FONT_STRETCHED, 0, 1);
   delay(2000);
   oledFill(0, 1);
-  for (i=0; i<3000; i++)
-  {
-    x = random(128);
-    y = random(64);
-    oledSetPixel(x, y, 1, 1);
-  }
   delay(2000);
+
+  if (rc != 2)          // TODO: verify that it works for SH1106 @ 0x3C
+  {
+    oledFill(0, 1);
+
+    for (i=0; i<3000; i++)
+    {
+      x = random(128);
+      y = random(64);
+      oledSetPixel(x, y, 1, 1);
+    }
+
+    delay(2000);
+  }
+
 //
 // By default, the line drawing function is disabled on AVR since it requires a backing buffer (1K RAM)
 // Which is usually a large % on most of the AVRs (Arduino UNO only has 2K RAM total)


### PR DESCRIPTION
I have replaced FONT_LARGE with FONT_STRETCHED (since _LARGE is disabled for AVR by default). Also I've found that oledSetPixel() does not work for my  SH1106 @ 0x3C display, so I put it under if() for 'TODO' clarifications.